### PR TITLE
use system-wide proxy for querying the API endpoint

### DIFF
--- a/Csslisible.py
+++ b/Csslisible.py
@@ -34,7 +34,7 @@ class CsslisibleCommand(sublime_plugin.TextCommand):
         return string
 
     def cssLisibleApiCall(self, string):
-        url = urllib.parse.urlparse(self.settings.get('csslisible_URL'))
+        url = self.settings.get('csslisible_URL')
         data = {
             'api': '1',
             'clean_css': string,
@@ -49,14 +49,12 @@ class CsslisibleCommand(sublime_plugin.TextCommand):
             'raccourcir_valeurs': self.settings.get('raccourcir_valeurs'),
         }
         params = urllib.parse.urlencode(data)
-        headers = {"Content-type": "application/x-www-form-urlencoded", "Accept": "text/plain"}
+        params = params.encode('utf8')
         try:
-            conn = http.client.HTTPConnection(url.netloc, timeout=5)
-            conn.request("POST", url.path, params, headers)
+            urllib.request.install_opener( urllib.request.build_opener( urllib.request.ProxyHandler()) )
+            response = urllib.request.urlopen(url, params, 5).read()
         except http.client.HTTPException as e:
             sublime.error_message('%s: HTTP error %s contacting API' % (__name__, str(e)))
         else:
-            response = conn.getresponse().read()
-            conn.close()
             return str(response, encoding='UTF-8')
         return False


### PR DESCRIPTION
Following what I've done in this pull request Sheeprider/Sublime-Csslisible#1, I've updated the code to allow the use of a system-wide proxy (using `urllib.request.ProxyHandler()`), but now this is absolutely transparent for the end user.
It uses the same API that @wbond recommands for installing Package Control at https://sublime.wbond.net/installation, and it's as simple as this:

```
url = 'http://www.youurl.com'
data = {
    'key': 'value',
    'key2': 'value',
    # [...]
}
params = urllib.parse.urlencode(data)
params = params.encode('utf8')
urllib.request.install_opener( urllib.request.build_opener( urllib.request.ProxyHandler()) )
response = urllib.request.urlopen(url, params, 5).read()
```

This way, the package will work everywhere, with or without system-proxy set.

Note: this pull request is based on the st3 branch, so it will only affect installation on Sublime Text 3, but an equivalent patch is also possible for Sublime Text 2 and python2.
